### PR TITLE
Full v2 parity: add veryquickscan, amlv3, docupass-detail (1.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 1.1.0 (2026-06-03)
+
+Full API v2 surface parity.
+
+### Added
+- `Scanner\VeryQuickScan` — `POST /veryquickscan` (fast OCR-only scan).
+- `AML\AMLV3Search` — `POST /amlv3` (AML v3 full-text / id lookup search).
+- `Docupass\DocupassDetail` — `GET /docupass/{reference}` (fetch a single Docupass).
+- Examples for the three new endpoints under `/example`.
+
+### Notes
+- Base URL is unchanged: US `https://api2.idanalyzer.com` (default), EU
+  `https://api2-eu.idanalyzer.com` via `new Client($key, "eu")`.
+- README corrected (removed copy-pasted "Python demos" / nodejs reference link).

--- a/README.md
+++ b/README.md
@@ -17,8 +17,29 @@ composer require idanalyzer/id-analyzer-v2-php-sdk
 ## Api Document
 [ID Analyzer Document](https://id-analyzer-v2.readme.io/docs/php)
 
+## Base URL / Region
+The SDK targets the US fleet (`https://api2.idanalyzer.com`) by default. To use
+the EU fleet (`https://api2-eu.idanalyzer.com`), pass the zone to the client:
+
+```php
+$client = new IDAnalyzer2\Client("YOUR_API_KEY", "eu"); // "us" (default) or "eu"
+```
+
+## API Coverage
+The SDK exposes the full ID Analyzer API v2 surface:
+
+- **Scanner** — `StandardScan` (`/scan`), `QuickScan` (`/quickscan`), `VeryQuickScan` (`/veryquickscan`)
+- **Biometric** — `FaceVerification` (`/face`), `LivenessVerification` (`/liveness`)
+- **AML** — `AMLSearch` (`/aml`), `AMLV3Search` (`/amlv3`)
+- **Contract** — `GenerateContract` (`/generate`) + template CRUD (`/contract`)
+- **Transaction** — list/detail/update/delete (`/transaction`), export, image/file vault
+- **Docupass** — `CreateDocupass`, `LsDocupass`, `DocupassDetail` (`/docupass/{reference}`), `RmDocupass`
+- **Profile** — KYC profile CRUD + export (`/profile`)
+- **Webhook** — list/resend/delete (`/webhook`)
+- **Account** — `MyAccount` (`/myaccount`)
+
 ## Example
-Check out **/example** folder for more Python demos.
+Check out the **/example** folder for usage demos.
 
 ## SDK Reference
-Check out [ID Analyzer PHP Reference](https://idanalyzer.github.io/id-analyzer-nodejs/)
+Check out [ID Analyzer PHP Reference](https://idanalyzer.github.io/id-analyzer-v2-php/)

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
       "role": "Developer"
     }
   ],
-  "version": "1.0.2",
+  "version": "1.1.0",
   "minimum-stability": "dev",
   "autoload": {
     "psr-4": {"IDAnalyzer2\\": "src/"}

--- a/example/AML/SearchV3.php
+++ b/example/AML/SearchV3.php
@@ -1,0 +1,28 @@
+<?php
+
+require_once __DIR__.'/../../vendor/autoload.php';
+
+use IDAnalyzer2\Client;
+use IDAnalyzer2\Api\AML\AMLV3Search;
+
+try {
+    $client = new Client("6EsqKOITW5Ge3cJYTGIGGNJZ3VmTEc64");
+
+    $s = new AMLV3Search();
+    $s->text = 'John Smith';
+    $s->limit = 10;
+    $s->page = 1;
+    [$result, $err] = $client->Do($s);
+    if ($err != null) {
+        echo 'ApiError：'.$err->message;
+        return;
+    }
+    //write file to current directory
+    file_put_contents('amlV3Search.json', json_encode($result));
+
+
+} catch (\IDAnalyzer2\SDKException $e) {
+    echo 'SDKException：'.$e->getMessage();
+} catch (Exception $e) {
+    echo 'Exceptipn：'.$e->getMessage();
+}

--- a/example/Docupass/Detail.php
+++ b/example/Docupass/Detail.php
@@ -1,0 +1,26 @@
+<?php
+
+require_once __DIR__.'/../../vendor/autoload.php';
+
+use IDAnalyzer2\Client;
+use IDAnalyzer2\Api\Docupass\DocupassDetail;
+
+try {
+    $client = new Client("6EsqKOITW5Ge3cJYTGIGGNJZ3VmTEc64");
+
+    $d = new DocupassDetail();
+    $d->reference = 'REPLACE_WITH_DOCUPASS_REFERENCE';
+    [$result, $err] = $client->Do($d);
+    if ($err != null) {
+        echo 'ApiError：'.$err->message;
+        return;
+    }
+    //write file to current directory
+    file_put_contents('docupassDetail.json', json_encode($result));
+
+
+} catch (\IDAnalyzer2\SDKException $e) {
+    echo 'SDKException：'.$e->getMessage();
+} catch (Exception $e) {
+    echo 'Exceptipn：'.$e->getMessage();
+}

--- a/example/Scan/VeryQuickScan.php
+++ b/example/Scan/VeryQuickScan.php
@@ -1,0 +1,30 @@
+<?php
+
+require_once __DIR__.'/../../vendor/autoload.php';
+
+use IDAnalyzer2\Client;
+use IDAnalyzer2\Api\Scanner\VeryQuickScan;
+
+try {
+    $imgBytes = file_get_contents('./1.jpg');
+
+    $client = new Client("6EsqKOITW5Ge3cJYTGIGGNJZ3VmTEc64");
+
+    $vscan = new VeryQuickScan();
+    $vscan->document = base64_encode($imgBytes);
+    $vscan->saveFile = true;
+
+    list($result, $err) = $client->Do($vscan);
+    if($err != null) {
+        echo 'ApiError：'.$err->message;
+        return;
+    }
+    //write file to current directory
+    file_put_contents('very_quick_scan_result.json', json_encode($result));
+
+
+} catch (\IDAnalyzer2\SDKException $e) {
+    echo 'SDKException：'.$e->getMessage();
+}  catch (Exception $e) {
+    echo 'Exceptipn：' . $e->getMessage();
+}

--- a/src/Api/AML/AMLV3Search.php
+++ b/src/Api/AML/AMLV3Search.php
@@ -1,0 +1,22 @@
+<?php
+namespace IDAnalyzer2\Api\AML;
+
+use IDAnalyzer2\ApiBase;
+use IDAnalyzer2\RequestPayload;
+use IDAnalyzer2\SDKException;
+
+class AMLV3Search extends ApiBase
+{
+    public string $uri = "/amlv3";
+    public string $method = "POST";
+
+    function __construct()
+    {
+        $this->initFields([
+            self::Field('text', 'string', false, null, "Full-text AML search query (name, alias, document/passport/tax/registration number, etc.). Either text or id is required."),
+            self::Field('id', 'string', false, null, 'One or more AML entity IDs to look up, separated by comma or newline (max 50). Either text or id is required.'),
+            self::Field('limit', 'integer', false, null, 'Number of results to return per page.'),
+            self::Field('page', 'integer', false, null, 'Result page number for pagination.'),
+        ]);
+    }
+}

--- a/src/Api/Docupass/DocupassDetail.php
+++ b/src/Api/Docupass/DocupassDetail.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace IDAnalyzer2\Api\Docupass;
+
+use IDAnalyzer2\ApiBase;
+use IDAnalyzer2\RequestPayload;
+
+
+class DocupassDetail extends ApiBase {
+    public string $uri = "/docupass/{reference}";
+    public string $method = "GET";
+
+    function __construct() {
+        $this->initFields([
+            self::RouteParam("reference", "string", true, null, "Docupass reference ID"),
+        ]);
+    }
+}

--- a/src/Api/Scanner/VeryQuickScan.php
+++ b/src/Api/Scanner/VeryQuickScan.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace IDAnalyzer2\Api\Scanner;
+
+use IDAnalyzer2\ApiBase;
+use IDAnalyzer2\RequestPayload;
+
+
+class VeryQuickScan extends ApiBase {
+    public string $uri = "/veryquickscan";
+    public string $method = "POST";
+
+    function __construct() {
+        $this->initFields([
+             self::Field("document", "string", true, null, "Base64-encoded Document Image"),
+             self::Field("documentBack", "string", false, null, "Base64-encoded Document(Back) Image"),
+             self::Field("saveFile", "boolean", false, null, "Cache uploaded image(s) for 24 hours and obtain a cache hash for each image, the reference hash can be used to start standard scan transaction without re-uploading the file."),
+        ]);
+    }
+}


### PR DESCRIPTION
Completes the v2 API surface for the PHP SDK (the parity reference for the SDK overhaul).

## Added
- `Scanner\VeryQuickScan` → `POST /veryquickscan`
- `AML\AMLV3Search` → `POST /amlv3`
- `Docupass\DocupassDetail` → `GET /docupass/{reference}`
- Matching `/example` demos for each
- `CHANGELOG.md`; README API-coverage + base-URL/region section; fixed README copy-paste ("Python demos" / nodejs link)
- Bumps composer version 1.0.2 → 1.1.0

## Notes
Base URL unchanged: US `https://api2.idanalyzer.com` (default), EU `https://api2-eu.idanalyzer.com` via `new Client($key, "eu")`. No behavior change to existing classes — purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)