### PR TITLE
README: use developer.idanalyzer.com KB domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 # ID Analyzer V2 PHP SDK
-This is a PHP SDK for [ID Analyzer Identity Verification APIs](https://www.idanalyzer.com), though all the APIs can be called with without the SDK using simple HTTP requests as outlined in the [documentation](https://idanalyzer.helptal.com/help), you can use this SDK to accelerate server-side development.
+This is a PHP SDK for [ID Analyzer Identity Verification APIs](https://www.idanalyzer.com), though all the APIs can be called with without the SDK using simple HTTP requests as outlined in the [documentation](https://developer.idanalyzer.com/help), you can use this SDK to accelerate server-side development.
 
 We strongly discourage users to connect to ID Analyzer API endpoint directly  from client-side applications that will be distributed to end user, such as mobile app, or in-browser JavaScript. Your API key could be easily compromised, and if you are storing your customer's information inside Vault they could use your API key to fetch all your user details. Therefore, the best practice is always to implement a client side connection to your server, and call our APIs from the server-side.
 
@@ -12,10 +12,10 @@ composer require idanalyzer/id-analyzer-v2-php-sdk
 ```
 
 ## Quick Start
-[Quick start with client library](https://idanalyzer.helptal.com/help/quick-start)
+[Quick start with client library](https://developer.idanalyzer.com/help/quick-start)
 
 ## Api Document
-[ID Analyzer Document](https://idanalyzer.helptal.com/help)
+[ID Analyzer Document](https://developer.idanalyzer.com/help)
 
 ## Base URL / Region
 The SDK targets the US fleet (`https://api2.idanalyzer.com`) by default. To use
@@ -42,4 +42,4 @@ The SDK exposes the full ID Analyzer API v2 surface:
 Check out the **/example** folder for usage demos.
 
 ## SDK Reference
-Check out [ID Analyzer PHP Reference](https://idanalyzer.helptal.com/help/php)
+Check out [ID Analyzer PHP Reference](https://developer.idanalyzer.com/help/php)


### PR DESCRIPTION
Switch README KB links from the temporary idanalyzer.helptal.com domain to the permanent developer.idanalyzer.com (same /help paths). README-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)