### PR TITLE
types: @property annotations on request classes (1.1.1)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
       "role": "Developer"
     }
   ],
-  "version": "1.1.0",
+  "version": "1.1.1",
   "minimum-stability": "dev",
   "autoload": {
     "psr-4": {"IDAnalyzer2\\": "src/"}

--- a/src/Api/AML/AMLSearch.php
+++ b/src/Api/AML/AMLSearch.php
@@ -5,6 +5,13 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $name
+ * @property string $idNumber
+ * @property int $entity
+ * @property string $country
+ * @property array $database
+ */
 class AMLSearch extends ApiBase
 {
     public string $uri = "/aml";

--- a/src/Api/AML/AMLV3Search.php
+++ b/src/Api/AML/AMLV3Search.php
@@ -5,6 +5,12 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $text
+ * @property string $id
+ * @property int $limit
+ * @property int $page
+ */
 class AMLV3Search extends ApiBase
 {
     public string $uri = "/amlv3";

--- a/src/Api/Biometric/FaceVerification.php
+++ b/src/Api/Biometric/FaceVerification.php
@@ -5,6 +5,14 @@ namespace IDAnalyzer2\Api\Biometric;
 use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 
+/**
+ * @property string $reference
+ * @property string $face
+ * @property string $faceVideo
+ * @property string $profile
+ * @property string $profileOverride
+ * @property string $customData
+ */
 class FaceVerification extends ApiBase
 {
     public string $uri = "/face";

--- a/src/Api/Biometric/LivenessVerification.php
+++ b/src/Api/Biometric/LivenessVerification.php
@@ -6,6 +6,13 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $face
+ * @property string $faceVideo
+ * @property string $profile
+ * @property array $profileOverride
+ * @property string $customData
+ */
 class LivenessVerification extends ApiBase
 {
     public string $uri = "/liveness";

--- a/src/Api/Contract/CreateTemplate.php
+++ b/src/Api/Contract/CreateTemplate.php
@@ -6,6 +6,13 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $name
+ * @property string $content
+ * @property string $orientation
+ * @property string $font
+ * @property string $timezone
+ */
 class CreateTemplate extends ApiBase
 {
     public string $uri = "/contract";

--- a/src/Api/Contract/EdTemplate.php
+++ b/src/Api/Contract/EdTemplate.php
@@ -7,6 +7,14 @@ use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
 
+/**
+ * @property string $name
+ * @property string $content
+ * @property string $orientation
+ * @property string $font
+ * @property string $timezone
+ * @property string $templateId
+ */
 class EdTemplate extends ApiBase
 {
     public string $uri = "/contract/{templateId}";

--- a/src/Api/Contract/GenerateContract.php
+++ b/src/Api/Contract/GenerateContract.php
@@ -6,6 +6,12 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $templateId
+ * @property string $format
+ * @property string $transactionId
+ * @property array $fillData
+ */
 class GenerateContract extends ApiBase
 {
     public string $uri = "/generate";

--- a/src/Api/Contract/LsTemplate.php
+++ b/src/Api/Contract/LsTemplate.php
@@ -6,6 +6,12 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
+/**
+ * @property int $limit
+ * @property int $offset
+ * @property int $order
+ * @property string $templateid
+ */
 class LsTemplate extends ApiBase
 {
     public string $uri = "/contract";

--- a/src/Api/Contract/RmTemplate.php
+++ b/src/Api/Contract/RmTemplate.php
@@ -5,6 +5,9 @@ namespace IDAnalyzer2\Api\Contract;
 use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $templateId
+ */
 class RmTemplate extends ApiBase
 {
     public string $uri = "/contract/{templateId}";

--- a/src/Api/Contract/TemplateDetail.php
+++ b/src/Api/Contract/TemplateDetail.php
@@ -6,6 +6,9 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $templateId
+ */
 class TemplateDetail extends ApiBase
 {
     public string $uri = "/contract/{templateId}";

--- a/src/Api/Docupass/CreateDocupass.php
+++ b/src/Api/Docupass/CreateDocupass.php
@@ -6,6 +6,27 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $profile
+ * @property string $mode
+ * @property string $verifyAddress
+ * @property string $verifyDocumentNumber
+ * @property string $verifyAge
+ * @property string $verifyName
+ * @property string $verifyDOB
+ * @property string $verifyPostcode
+ * @property string $userPhone
+ * @property string $customData
+ * @property string $language
+ * @property bool $reusable
+ * @property string $referenceDocument
+ * @property string $referenceDocumentBack
+ * @property string $referenceFace
+ * @property string $contractGenerate
+ * @property string $contractSign
+ * @property string $contractFormat
+ * @property array $contractPrefill
+ */
 class CreateDocupass extends ApiBase
 {
     public string $uri = "/docupass";

--- a/src/Api/Docupass/DocupassDetail.php
+++ b/src/Api/Docupass/DocupassDetail.php
@@ -6,6 +6,9 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 
 
+/**
+ * @property string $reference
+ */
 class DocupassDetail extends ApiBase {
     public string $uri = "/docupass/{reference}";
     public string $method = "GET";

--- a/src/Api/Docupass/LsDocupass.php
+++ b/src/Api/Docupass/LsDocupass.php
@@ -6,6 +6,20 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 
 
+/**
+ * @property string $sort
+ * @property string $order
+ * @property string $offset
+ * @property string $limit
+ * @property string $reference
+ * @property string $customData
+ * @property string $profileId
+ * @property string $decision
+ * @property string $createdAtMin
+ * @property string $createdAtMax
+ * @property string $completedAtMin
+ * @property string $completedAtMax
+ */
 class LsDocupass extends ApiBase {
     public string $uri = "/docupass";
     public string $method = "GET";

--- a/src/Api/Docupass/RmDocupass.php
+++ b/src/Api/Docupass/RmDocupass.php
@@ -6,6 +6,9 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 
 
+/**
+ * @property string $reference
+ */
 class RmDocupass extends ApiBase {
     public string $uri = "/docupass/{reference}";
     public string $method = "DELETE";

--- a/src/Api/Profile/CreateProfile.php
+++ b/src/Api/Profile/CreateProfile.php
@@ -6,6 +6,31 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $name
+ * @property mixed $canvasSize
+ * @property bool $orientationCorrection
+ * @property bool $objectDetection
+ * @property bool $AAMVABarcodeParsing
+ * @property bool $saveResult
+ * @property bool $saveImage
+ * @property bool $outputImage
+ * @property string $outputType
+ * @property bool $crop
+ * @property bool $advancedCrop
+ * @property mixed $outputSize
+ * @property bool $inferFullName
+ * @property bool $splitFirstName
+ * @property bool $transactionAuditReport
+ * @property string $timezone
+ * @property array $obscure
+ * @property string $webhook
+ * @property array $thresholds
+ * @property array $decisionTrigger
+ * @property array $decisions
+ * @property array $docupass
+ * @property array $acceptedDocuments
+ */
 class CreateProfile extends ApiBase
 {
     public string $uri = "/profile";

--- a/src/Api/Profile/EdProfile.php
+++ b/src/Api/Profile/EdProfile.php
@@ -6,6 +6,32 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $name
+ * @property mixed $canvasSize
+ * @property bool $orientationCorrection
+ * @property bool $objectDetection
+ * @property bool $AAMVABarcodeParsing
+ * @property bool $saveResult
+ * @property bool $saveImage
+ * @property bool $outputImage
+ * @property string $outputType
+ * @property bool $crop
+ * @property bool $advancedCrop
+ * @property mixed $outputSize
+ * @property bool $inferFullName
+ * @property bool $splitFirstName
+ * @property bool $transactionAuditReport
+ * @property string $timezone
+ * @property array $obscure
+ * @property string $webhook
+ * @property array $thresholds
+ * @property array $decisionTrigger
+ * @property array $decisions
+ * @property array $docupass
+ * @property array $acceptedDocuments
+ * @property string $profileId
+ */
 class EdProfile extends ApiBase
 {
     public string $uri = "/profile/{profileId}";

--- a/src/Api/Profile/ExportProfile.php
+++ b/src/Api/Profile/ExportProfile.php
@@ -6,6 +6,9 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $profileId
+ */
 class ExportProfile extends ApiBase
 {
     public string $uri = "/export/profile/{profileId}";

--- a/src/Api/Profile/ProfileDetail.php
+++ b/src/Api/Profile/ProfileDetail.php
@@ -6,6 +6,9 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $profileId
+ */
 class ProfileDetail extends ApiBase
 {
     public string $uri = "/profile/{profileId}";

--- a/src/Api/Profile/RmProfile.php
+++ b/src/Api/Profile/RmProfile.php
@@ -5,6 +5,9 @@ namespace IDAnalyzer2\Api\Profile;
 use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $profileId
+ */
 class RmProfile extends ApiBase
 {
     public string $uri = "/profile/{profileId}";

--- a/src/Api/Scanner/QuickScan.php
+++ b/src/Api/Scanner/QuickScan.php
@@ -6,6 +6,11 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 
 
+/**
+ * @property string $document
+ * @property string $documentBack
+ * @property bool $saveFile
+ */
 class QuickScan extends ApiBase {
     public string $uri = "/quickscan";
     public string $method = "POST";

--- a/src/Api/Scanner/StandardScan.php
+++ b/src/Api/Scanner/StandardScan.php
@@ -7,6 +7,28 @@ use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
 
+/**
+ * @property string $document
+ * @property string $documentBack
+ * @property string $face
+ * @property string $faceVideo
+ * @property string $profile
+ * @property array $profileOverride
+ * @property string $restrictCountry
+ * @property string $restrictState
+ * @property string $restrictType
+ * @property string $verifyName
+ * @property string $verifyDob
+ * @property string $verifyAge
+ * @property string $verifyAddress
+ * @property string $verifyPostcode
+ * @property string $verifyDocumentNumber
+ * @property string $contractGenerate
+ * @property string $contractFormat
+ * @property array $contractPrefill
+ * @property string $ip
+ * @property string $customData
+ */
 class StandardScan extends ApiBase
 {
     public string $uri = "/scan";

--- a/src/Api/Scanner/VeryQuickScan.php
+++ b/src/Api/Scanner/VeryQuickScan.php
@@ -6,6 +6,11 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 
 
+/**
+ * @property string $document
+ * @property string $documentBack
+ * @property bool $saveFile
+ */
 class VeryQuickScan extends ApiBase {
     public string $uri = "/veryquickscan";
     public string $method = "POST";

--- a/src/Api/Transaction/EdTransaction.php
+++ b/src/Api/Transaction/EdTransaction.php
@@ -5,6 +5,10 @@ namespace IDAnalyzer2\Api\Transaction;
 use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $decision
+ * @property string $transactionId
+ */
 class EdTransaction extends ApiBase
 {
     public string $uri = "/transaction/{transactionId}";

--- a/src/Api/Transaction/ExportTransaction.php
+++ b/src/Api/Transaction/ExportTransaction.php
@@ -6,6 +6,18 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $exportType
+ * @property bool $ignoreUnrecognized
+ * @property bool $ignoreDuplicate
+ * @property array $transactionId
+ * @property string $customData
+ * @property string $profileId
+ * @property string $decision
+ * @property string $createdAtMin
+ * @property string $createdAtMax
+ * @property string $docupass
+ */
 class ExportTransaction extends ApiBase
 {
     public string $uri = "/export/transaction";

--- a/src/Api/Transaction/LsTransaction.php
+++ b/src/Api/Transaction/LsTransaction.php
@@ -6,6 +6,17 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
+/**
+ * @property int $limit
+ * @property int $offset
+ * @property int $order
+ * @property string $profileId
+ * @property string $decision
+ * @property string $customData
+ * @property string $createdAtMin
+ * @property string $createdAtMax
+ * @property string $docupass
+ */
 class LsTransaction extends ApiBase
 {
     public string $uri = "/transaction";

--- a/src/Api/Transaction/OutputFile.php
+++ b/src/Api/Transaction/OutputFile.php
@@ -5,6 +5,9 @@ namespace IDAnalyzer2\Api\Transaction;
 use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $fileName
+ */
 class OutputFile extends ApiBase
 {
     public string $uri = "/filevault/{fileName}";

--- a/src/Api/Transaction/OutputImage.php
+++ b/src/Api/Transaction/OutputImage.php
@@ -6,6 +6,9 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $imageToken
+ */
 class OutputImage extends ApiBase
 {
     public string $uri = "/imagevault/{imageToken}";

--- a/src/Api/Transaction/RmTransaction.php
+++ b/src/Api/Transaction/RmTransaction.php
@@ -5,6 +5,9 @@ namespace IDAnalyzer2\Api\Transaction;
 use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $transactionId
+ */
 class RmTransaction extends ApiBase
 {
     public string $uri = "/transaction/{transactionId}";

--- a/src/Api/Transaction/TransactionDetail.php
+++ b/src/Api/Transaction/TransactionDetail.php
@@ -6,6 +6,9 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $transactionId
+ */
 class TransactionDetail extends ApiBase
 {
     public string $uri = "/transaction/{transactionId}";

--- a/src/Api/Webhook/LsWebhook.php
+++ b/src/Api/Webhook/LsWebhook.php
@@ -6,6 +6,15 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
+/**
+ * @property int $limit
+ * @property int $offset
+ * @property int $order
+ * @property string $event
+ * @property int $success
+ * @property string $createdAtMin
+ * @property string $createdAtMax
+ */
 class LsWebhook extends ApiBase
 {
     public string $uri = "/webhook";

--- a/src/Api/Webhook/ResendWebhook.php
+++ b/src/Api/Webhook/ResendWebhook.php
@@ -5,6 +5,9 @@ namespace IDAnalyzer2\Api\Webhook;
 use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $webhookId
+ */
 class ResendWebhook extends ApiBase
 {
     public string $uri = "/webhook/{webhookId}";

--- a/src/Api/Webhook/RmWebhook.php
+++ b/src/Api/Webhook/RmWebhook.php
@@ -6,6 +6,9 @@ use IDAnalyzer2\ApiBase;
 use IDAnalyzer2\RequestPayload;
 use IDAnalyzer2\SDKException;
 
+/**
+ * @property string $webhookId
+ */
 class RmWebhook extends ApiBase
 {
     public string $uri = "/webhook/{webhookId}";


### PR DESCRIPTION
Adds @property PHPDoc to every request class (generated from initFields) so IDEs and AI editor agents get real autocomplete + types for the magic (__set) fields. Patch release 1.1.1.