### PR TITLE
KYB: require a document (document + optional profile)

### DIFF
--- a/example/KYB/Verify.php
+++ b/example/KYB/Verify.php
@@ -10,14 +10,13 @@ try {
 
     // Verify a business from its registration/incorporation document: extract
     // details, check official company registries, screen against sanctions/PEP,
-    // and return directors/owners to verify.
+    // and return directors/owners to verify. A document is required; an optional
+    // profile selects the KYC profile.
     $kyb = new KYBVerify();
     $kyb->document = base64_encode(file_get_contents('./registration.jpg'));
 
-    // Or verify from known business details:
-    // $kyb->legalName          = "ACME CORPORATION";
-    // $kyb->registrationNumber = "12345678";
-    // $kyb->countryIso2        = "US";
+    // Optionally apply a KYC profile:
+    // $kyb->profile = "your-profile-id";
 
     [$result, $err] = $client->Do($kyb);
     if ($err != null) {

--- a/src/Api/KYB/KYBVerify.php
+++ b/src/Api/KYB/KYBVerify.php
@@ -8,22 +8,13 @@ use IDAnalyzer2\SDKException;
 /**
  * Request for the KYB (Know Your Business) Verify endpoint (`POST /kyb`).
  *
- * Verifies a business from its registration/incorporation document: extracts
+ * Verify a business from its registration/incorporation document. A document is
+ * required; an optional profile selects the KYC profile. The endpoint extracts
  * the company details, checks official company registries, screens against
- * sanctions/PEP watchlists, and returns directors and owners to verify. You may
- * supply a registration/incorporation document and/or known business
- * identifiers; at least one of {@see $document}, {@see $legalName} or
- * {@see $registrationNumber} is required.
+ * sanctions/PEP watchlists, and returns directors and owners to verify.
  *
  * @property string $document
- * @property string $legalName
- * @property string $legalNameLocal
- * @property string $registrationNumber
- * @property string $taxNumber
- * @property string $lei
- * @property string $entityType
- * @property string $countryIso2
- * @property string $state
+ * @property string $profile
  */
 class KYBVerify extends ApiBase
 {
@@ -38,33 +29,24 @@ class KYBVerify extends ApiBase
     function __construct()
     {
         $this->initFields([
-            self::Field('document', 'string', false, null, 'Base64-encoded registration/incorporation document, a URL, or a "ref:abcde" reference to an image from another transaction.'),
-            self::Field('legalName', 'string', false, null, 'Registered legal name of the business.'),
-            self::Field('legalNameLocal', 'string', false, null, 'Registered legal name of the business in the local language/script.'),
-            self::Field('registrationNumber', 'string', false, null, 'Company registration / incorporation number.'),
-            self::Field('taxNumber', 'string', false, null, 'Business tax number.'),
-            self::Field('lei', 'string', false, null, 'Legal Entity Identifier (LEI).'),
-            self::Field('entityType', 'string', false, null, 'Business entity type.'),
-            self::Field('countryIso2', 'string', false, null, 'Two-letter ISO country code where the business is registered.'),
-            self::Field('state', 'string', false, null, 'State/province where the business is registered.'),
+            self::Field('document', 'string', true, null, 'Base64-encoded registration/incorporation document (image or PDF), a URL, or a "ref:abcde" reference to a document from another transaction.'),
+            self::Field('profile', 'string', false, null, 'Optional KYC profile to apply to the verification.'),
         ]);
     }
 
     /**
      * Validate the request before it is sent.
      *
-     * In addition to the base required-field checks, at least one of
-     * {@see $document}, {@see $legalName} or {@see $registrationNumber} must be
-     * supplied.
+     * A business document is required.
      *
      * @return void
      *
-     * @throws SDKException If none of document, legalName or registrationNumber is set.
+     * @throws SDKException If document is empty/missing.
      */
     public function validate() {
         parent::validate();
-        if ($this->document === null && $this->legalName === null && $this->registrationNumber === null) {
-            throw new SDKException("Provide a document, or legalName/registrationNumber.");
+        if ($this->document === null || $this->document === '') {
+            throw new SDKException("A business document (image or PDF) is required.");
         }
     }
 }


### PR DESCRIPTION
KYB now requires a business document; the data-only (name/number) lookup is removed. The request takes only the document plus an optional profile.